### PR TITLE
refactor: Change extension entrypoint to sphinxnotes.snippet (2nd)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,7 +152,7 @@ comboroles_roles = {
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../src/sphinxnotes'))
-extensions.append('snippet.ext')
+extensions.append('snippet')
 
 # DOG FOOD CONFIGURATION START
 

--- a/src/sphinxnotes/snippet/__init__.py
+++ b/src/sphinxnotes/snippet/__init__.py
@@ -1,0 +1,36 @@
+"""
+sphinxnotes.snippet
+~~~~~~~~~~~~~~~~~~~
+
+Sphinx extension entrypoint.
+
+:copyright: Copyright 2024 Shengyu Zhang
+:license: BSD, see LICENSE for details.
+"""
+
+
+def setup(app):
+    # **WARNING**: We don't import these packages globally, because the current
+    # package (sphinxnotes.snippet) is always resloved when importing
+    # sphinxnotes.snippet.*. If we import packages here, eventually we will
+    # load a lot of packages from the Sphinx. It will seriously **SLOW DOWN**
+    # the startup time of our CLI tool (sphinxnotes.snippet.cli).
+    #
+    # .. seealso:: https://github.com/sphinx-notes/snippet/pull/31
+    from .ext import (
+        SnippetBuilder,
+        on_config_inited,
+        on_env_get_outdated,
+        on_doctree_resolved,
+        on_builder_finished,
+    )
+
+    app.add_builder(SnippetBuilder)
+
+    app.add_config_value('snippet_config', {}, '')
+    app.add_config_value('snippet_patterns', {'*': ['.*']}, '')
+
+    app.connect('config-inited', on_config_inited)
+    app.connect('env-get-outdated', on_env_get_outdated)
+    app.connect('doctree-resolved', on_doctree_resolved)
+    app.connect('build-finished', on_builder_finished)

--- a/src/sphinxnotes/snippet/cache.py
+++ b/src/sphinxnotes/snippet/cache.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import List, Tuple, Dict, Optional
 from dataclasses import dataclass
 
-from . import Snippet
+from .snippets import Snippet
 from .utils.pdict import PDict
 
 

--- a/src/sphinxnotes/snippet/cli.py
+++ b/src/sphinxnotes/snippet/cli.py
@@ -14,11 +14,12 @@ from os import path
 from textwrap import dedent
 from shutil import get_terminal_size
 import posixpath
+from importlib.metadata import version
 
 from xdg.BaseDirectory import xdg_config_home
 from sphinx.util.matching import patmatch
 
-from . import __version__, Document
+from .snippets import Document
 from .config import Config
 from .cache import Cache, IndexID, Index
 from .table import tablify, COLUMNS
@@ -61,7 +62,10 @@ def main(argv: List[str] = sys.argv[1:]):
                                        * (any)               wildcard for any snippet"""),
     )
     parser.add_argument(
-        '-v', '--version', action='version', version='%(prog)s ' + __version__
+        '-v',
+        '--version',
+        action='version',
+        version='%(prog)s ' + version('sphinxnotes.any'),
     )
     parser.add_argument(
         '-c', '--config', default=DEFAULT_CONFIG_FILE, help='path to configuration file'

--- a/src/sphinxnotes/snippet/ext.py
+++ b/src/sphinxnotes/snippet/ext.py
@@ -1,10 +1,10 @@
 """
-sphinxnotes.ext.snippet
+sphinxnotes.snippet.ext
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Sphinx extension for sphinxnotes.snippet.
+Sphinx extension implementation, but the entrypoint is located at __init__.py.
 
-:copyright: Copyright 2021 Shengyu Zhang
+:copyright: Copyright 2024 Shengyu Zhang
 :license: BSD, see LICENSE for details.
 """
 
@@ -206,15 +206,3 @@ def _format_modified_time(timestamp: float) -> str:
     """Return an RFC 3339 formatted string representing the given timestamp."""
     seconds, fraction = divmod(timestamp, 1)
     return time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(seconds)) + f'.{fraction:.3f}'
-
-
-def setup(app: Sphinx):
-    app.add_builder(SnippetBuilder)
-
-    app.add_config_value('snippet_config', {}, '')
-    app.add_config_value('snippet_patterns', {'*': ['.*']}, '')
-
-    app.connect('config-inited', on_config_inited)
-    app.connect('env-get-outdated', on_env_get_outdated)
-    app.connect('doctree-resolved', on_doctree_resolved)
-    app.connect('build-finished', on_builder_finished)

--- a/src/sphinxnotes/snippet/ext.py
+++ b/src/sphinxnotes/snippet/ext.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 from .config import Config
-from . import Snippet, WithTitle, Document, Section
+from .snippets import Snippet, WithTitle, Document, Section
 from .picker import pick
 from .cache import Cache, Item
 from .keyword import Extractor

--- a/src/sphinxnotes/snippet/picker.py
+++ b/src/sphinxnotes/snippet/picker.py
@@ -15,7 +15,7 @@ from docutils import nodes
 
 from sphinx.util import logging
 
-from . import Snippet, Section, Document
+from .snippets import Snippet, Section, Document
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx

--- a/src/sphinxnotes/snippet/snippets.py
+++ b/src/sphinxnotes/snippet/snippets.py
@@ -1,8 +1,10 @@
 """
-sphinxnotes.snippet
-~~~~~~~~~~~~~~~~~~~
+sphinxnotes.snippet.snippets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: Copyright 2020 Shengyu Zhang
+Definitions of various snippets.
+
+:copyright: Copyright 2024 Shengyu Zhang
 :license: BSD, see LICENSE for details.
 """
 
@@ -16,14 +18,13 @@ from docutils import nodes
 if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
 
-__version__ = '1.1.1'
-
 
 class Snippet(object):
     """
-    Snippet is base class of reStructuredText snippet.
+    Snippet is structured fragments extracted from a single Sphinx document
+    (can also be said to be a reStructuredText file).
 
-    :param nodes: Document nodes that make up this snippet
+    :param nodes: nodes of doctree that make up this snippet.
     """
 
     #: docname where the snippet is located, can be referenced by


### PR DESCRIPTION
Replace https://github.com/sphinx-notes/snippet/pull/31, with non-golbal import :D 

```
#34:
import time:       190 |      20072 | sphinxnotes.snippet.cli
#v2
import time:       338 |      41215 | sphinxnotes.snippet.cli
#31
import time:       320 |     481846 | sphinxnotes.snippet.cli

